### PR TITLE
Fix string for spawning process

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,7 @@ static const std::vector<Rule> rules = {};
 std::vector<Keybind> keybinds = {
     { modkey, XK_q, "kill_client", { .v = nullptr } },
     { modkey, XK_f, "toggle_fullscreen", { .v = nullptr } },
-    { modkey, XK_p, "spawn", { .s = { "/bin/sh", "-c", "echo", NULL } } },
+    { modkey, XK_p, "spawn", { .s = "echo" } },
 };
 
 }


### PR DESCRIPTION
It's currently passing an array of strings that will end up in reinterpreting pointers as a string.
The `m_spawn` function already calls `/bin/sh` as well, so it's redundant to call it in the argument.